### PR TITLE
Simplify and fix sound playback

### DIFF
--- a/src/Sounds.cpp
+++ b/src/Sounds.cpp
@@ -31,13 +31,10 @@ void SoundManager::playSound(std::string input)
     {
         if (sounds.at(i).name == input)
         {
-            //return sounds.at(i).soundstorage;
-            SoundPlayer SP;
-            SP.sound.setBuffer(sounds[i].soundstorage);
-            SP.sound.setVolume(gvars::soundVolume);
-            //SP.sound.play();
-            playSounds.push_back(SP);
-            playSounds.back().sound.play();
+            auto sound = std::make_unique<sf::Sound>(sounds[i].soundstorage);
+            sound->setVolume(gvars::soundVolume);
+            playSounds.push_back(std::move(sound));
+            playSounds.back()->play();
             return;
         }
     }
@@ -46,57 +43,21 @@ void SoundManager::playSound(std::string input)
         if (sounds.at(i).name == "Error.wav")
         {
             //return sounds.at(i).soundstorage;
-            SoundPlayer SP;
-            SP.sound.setBuffer(sounds[i].soundstorage);
-            SP.sound.setVolume(gvars::soundVolume);
-            playSounds.push_back(SP);
-            playSounds.back().sound.play();
+            auto sound = std::make_unique<sf::Sound>(sounds[i].soundstorage);
+            sound->setVolume(gvars::soundVolume);
+            playSounds.push_back(std::move(sound));
+            playSounds.back()->play();
             return;
-        }
-    }
-}
-
-SoundPlayer::SoundPlayer()
-{
-    toDelete = false;
-}
-
-void checkSounds(std::vector<SoundPlayer> &playsound)
-{
-    for (auto &i : playsound)
-    {
-        SoundPlayer SP;
-        //SP.sound.getStatus
-        //std::cout << "Sound Status: " << i.sound.getStatus() << ", VS: " << sf::Sound::Status::Stopped << std::endl;
-        if(i.sound.getStatus() == sf::Sound::Status::Stopped)
-        {
-            i.toDelete = true;
         }
     }
 }
 
 void SoundManager::cleanSounds()
 {
-    checkSounds(playSounds);
-    bool done = false;
-    while (done == false)
-    {
-        bool yet = false;
-        for (auto it = playSounds.begin(); it != playSounds.end(); ++it)
-        {
-            if (it->toDelete)
-            {
-                //std::cout << it->name << " to be deleted. \n";
-                playSounds.erase(it);
-                yet = true;
-                break;
-            }
-        }
-        if (yet == false)
-        {
-            done = true;
-        }
-    }
+    auto it = std::remove_if(playSounds.begin(), playSounds.end(), [](auto const & s) {
+        return s->getStatus() == sf::Sound::Stopped;
+    });
+    playSounds.erase(it, playSounds.end());
 }
 
 void SoundManager::init()

--- a/src/Sounds.h
+++ b/src/Sounds.h
@@ -11,20 +11,11 @@ public:
     std::string name;
 };
 
-class SoundPlayer
-{
-    public:
-    sf::Sound sound;
-    std::string name;
-    bool toDelete;
-    SoundPlayer();
-};
-
 class SoundManager
 {
 public:
     std::vector<SoundHolder> sounds;
-    std::vector<SoundPlayer> playSounds;
+    std::vector<std::unique_ptr<sf::Sound>> playSounds;
     sf::SoundBuffer &getSound(std::string input);
     void cleanSounds();
     void playSound(std::string input);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5154,8 +5154,6 @@ int main()
 
         debug("Starting Removing process, NPC/Unpoint/Items/GC.Menu");
 
-        AnyDeletes(soundmanager.playSounds);
-
         removeNPCs(npclist, mutex::npcList);
         removeItems(worlditems);
         soundmanager.cleanSounds();


### PR DESCRIPTION
Wrap the sf::Sound instances in std::unique_ptr to avoid implicitly
copying them, and thus invoking their destructor.

Also remove SoundPlayer class, as it seems redundant.
