### PR TITLE
Fix compilation error with Clang

### DIFF
--- a/src/BountyTower.cpp
+++ b/src/BountyTower.cpp
@@ -2469,7 +2469,7 @@ void renderMerchantMenu(baseMenu &menu)
 
 
         // Types: All, Weapons, Ammo, Aid, Misc
-        int totalTypes = 7;
+        const int totalTypes = 7;
         std::string types[totalTypes] = {"All", "Weapons", "Ammo", "Magic", "Engineer", "Aid", "Misc"};
 
 
@@ -3260,7 +3260,7 @@ void renderEnchantMenu(baseMenu &menu)
 
 
         // Types: All, Weapons, Ammo, Aid, Misc
-        int totalTypes = 7;
+        const int totalTypes = 7;
         std::string types[totalTypes] = {"All", "Weapons", "Ammo", "Magic", "Engineer", "Aid", "Misc"};
 
         for(int i = 0; i != totalTypes; i++)
@@ -6389,4 +6389,3 @@ namespace bountytower
     bool floorCleared = false;
     bool gameBeaten = false;
 }
-


### PR DESCRIPTION
Standard C++ does not allow dynamically sized arrays, so Clang rejects
this code.

Fix it by making totalTypes const.
